### PR TITLE
Chat session are not maintained

### DIFF
--- a/vxml/chatbots/chatbot_pandorabots.vxml
+++ b/vxml/chatbots/chatbot_pandorabots.vxml
@@ -36,7 +36,7 @@
         <script>log(name+'(): '+answer);</script>
       </if>
       <if cond="api.hasOwnProperty('sessionid')">
-        <assign name="sessionid" expr="false"/>
+        <assign name="sessionid" expr="api.sessionid"/>
       </if>
 
     </block>


### PR DESCRIPTION
Session id was not stored anywhere to pass in the next request. This resulted in each request being treated as a unique session.